### PR TITLE
Specify Ubuntu version and be less specific about Python version

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,10 +4,10 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6.8"]
+        python-version: ["3.6"]
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Mostly to deal with this change:
https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/