### PR TITLE
Fix add_interface_address

### DIFF
--- a/aquilon/netbox2aquilon
+++ b/aquilon/netbox2aquilon
@@ -302,22 +302,26 @@ def _netbox_copy_interfaces(device):
                 f'--interface {interface.name}',
                 '--boot',
             ]))
+    return cmds
 
+def _netbox_copy_addresses(device):
+    cmds = []
+    interfaces = _get_interfaces_from_device(device)
+    for interface in interfaces:
         addresses = _get_addresses_from_interface(interface)
         for address in addresses:
-            # Don't add the primary IP as add_host will do this
-            # If there is no dns_name in netbox for the address do not do this as we have
-            # not done the add_host so there is no primary name for the host, so the fqdn
-            # will be needed by add_interface_address
-            if address.address != device.primary_ip.address and address.dns_name:
+            # Don't add the primary IP as add_host does this
+            if address.address != device.primary_ip.address:
                 # Remove prefix length as aquilon gets this from the network definition
                 address.address = address.address.split('/')[0]
-                cmd = ['add_interface_address',
-                       f'--machine {device.aq_machine_name}',
-                       f'--interface {interface.name}',
-                       f'--ip {address.address}',
-                       f'--fqdn {address.dns_name}'
-                      ]
+                cmd = [
+                    'add_interface_address',
+                    f'--machine {device.aq_machine_name}',
+                    f'--interface {interface.name}',
+                    f'--ip {address.address}',
+                ]
+                if address.dns_name:
+                    cmd.append(f'--fqdn {address.dns_name}')
                 if address.vrf:
                     cmd.append(f'--network_environment {address.vrf}')
                 cmds.append(' '.join(cmd))
@@ -370,6 +374,9 @@ def _netbox_copy(opts):
         f'--osname {opts.osname}',
         f'--osversion {opts.osvers}',
     ]))
+
+    # Add additional addresses to non-primary interfaces
+    cmds.extend(_netbox_copy_addresses(device))
 
     _call_aq(opts, cmds)
 

--- a/aquilon/netbox2aquilon
+++ b/aquilon/netbox2aquilon
@@ -306,17 +306,21 @@ def _netbox_copy_interfaces(device):
         addresses = _get_addresses_from_interface(interface)
         for address in addresses:
             # Don't add the primary IP as add_host will do this
-            if address.address != device.primary_ip.address:
+            # If there is no dns_name in netbox for the address do not do this as we have
+            # not done the add_host so there is no primary name for the host, so the fqdn
+            # will be needed by add_interface_address
+            if address.address != device.primary_ip.address and address.dns_name:
                 # Remove prefix length as aquilon gets this from the network definition
                 address.address = address.address.split('/')[0]
-                cmds.append(' '.join([
-                    'add_interface_address',
-                    f'--machine {device.aq_machine_name}',
-                    f'--interface {interface.name}',
-                    f'--fqdn {address.dns_name}' if address.dns_name else '\b',
-                    f'--network_environment {address.vrf}' if address.vrf else '\b',
-                    f'--ip {address.address}',
-                ]))
+                cmd = ['add_interface_address',
+                       f'--machine {device.aq_machine_name}',
+                       f'--interface {interface.name}',
+                       f'--ip {address.address}',
+                       f'--fqdn {address.dns_name}'
+                      ]
+                if address.vrf:
+                    cmd.append(f'--network_environment {address.vrf}')
+                cmds.append(' '.join(cmd))
     return cmds
 
 


### PR DESCRIPTION
Don't attempt to add_interface_address if there is no dns_name entry in netbox for the ip address