### PR TITLE
netbox2aquilon: Fall back to inventory personality if the generated personality can't be found

### DIFF
--- a/aquilon/netbox2aquilon.py
+++ b/aquilon/netbox2aquilon.py
@@ -47,7 +47,7 @@ class Netbox2Aquilon(SCDNetbox):
                         cmd,
                         retval,
                     )
-                    sys.exit(1)
+                return retval
 
     def _netbox_get_device(self, opts):
         if opts.magdb_id:
@@ -232,7 +232,7 @@ class Netbox2Aquilon(SCDNetbox):
         # Add additional addresses to non-primary interfaces
         cmds.extend(self._netbox_copy_addresses(device))
 
-        self._call_aq(opts, cmds)
+        sys.exit(self._call_aq(opts, cmds))
 
 
 def _main():

--- a/aquilon/netbox2aquilon.py
+++ b/aquilon/netbox2aquilon.py
@@ -54,6 +54,13 @@ class Netbox2Aquilon(SCDNetbox):
                 process.returncode,
             )
             return process.returncode
+        if not process.stdout and not process.stderr:
+            logging.debug(
+                'Commmand %s %s returned no data',
+                self.config['aquilon']['cli_path'],
+                cmd,
+            )
+            return -1
         return 0
 
     def _call_aq_cmds(self, cmds, dryrun=False):
@@ -62,7 +69,9 @@ class Netbox2Aquilon(SCDNetbox):
                 print('aq ' + cmd)
             else:
                 retval = self._call_aq(cmd)
-                return retval
+                if retval > 0:
+                    return retval
+        return 0
 
     def _netbox_get_device(self, opts):
         if opts.magdb_id:

--- a/aquilon/netbox2aquilon.py
+++ b/aquilon/netbox2aquilon.py
@@ -41,6 +41,11 @@ class Netbox2Aquilon(SCDNetbox):
             stderr=subprocess.PIPE,
             check=False,
         )
+        logging.debug(
+            'Calling %s %s',
+            self.config['aquilon']['cli_path'],
+            cmd,
+        )
         if process.returncode != 0:
             logging.error(
                 'Commmand %s %s exited with error code %d',

--- a/aquilon/netbox2aquilon.py
+++ b/aquilon/netbox2aquilon.py
@@ -234,6 +234,11 @@ class Netbox2Aquilon(SCDNetbox):
             logging.error('Unsupported device type to copy "%s"', type(device))
             sys.exit(1)
 
+        # Fall back to inventory personality if specific personality can't be found
+        if self._call_aq(f'search_personality --personality {personality}') < 0:
+            logging.info('Personality "%s" not found, falling back to "inventory"', personality)
+            personality = 'inventory'
+
         if not personality:
             logging.error('Unable to determine personality of device "%s"', type(device))
             sys.exit(1)


### PR DESCRIPTION
Currently personality is built up from the device's role and tenant, e.g. `server-tier1`, many of these do not and will not exist, so fall back to `inventory` in this case.

Resolves #22.