### PR TITLE
Fully fix osversion

### DIFF
--- a/aquilon/netbox2aquilon.py
+++ b/aquilon/netbox2aquilon.py
@@ -226,7 +226,7 @@ class Netbox2Aquilon(SCDNetbox):
             f'--personality {personality}',
             f'--{aqdesttype} {aqdestval}',
             f'--osname {opts.osname}',
-            f'--osversion {opts.osvers}',
+            f'--osversion {opts.osversion}',
         ]))
 
         # Add additional addresses to non-primary interfaces


### PR DESCRIPTION
osversion parameter had been changed, but not the variable used when printing the command, leading it to fall back to a default value

Fixes #27 