### PR TITLE
Handle hostnames with multiple addresses and ignore IPv6

### DIFF
--- a/aquilon/netbox2aquilon.py
+++ b/aquilon/netbox2aquilon.py
@@ -61,7 +61,7 @@ class Netbox2Aquilon(SCDNetbox):
             sys.exit(2)
 
         # check if device has a primary ip
-        if device.primary_ip is None:
+        if device.primary_ip4 is None:
             logging.error("No primary IP defined for host")
             sys.exit(1)
 
@@ -166,7 +166,7 @@ class Netbox2Aquilon(SCDNetbox):
             addresses = self.get_addresses_from_interface(interface)
             for address in addresses:
                 # Don't add the primary IP as add_host does this
-                if address.address != device.primary_ip.address:
+                if address.address != device.primary_ip4.address:
                     # Remove prefix length as aquilon gets this from the network definition
                     address.address = address.address.split('/')[0]
                     cmd = [
@@ -220,10 +220,10 @@ class Netbox2Aquilon(SCDNetbox):
         # Finally add the host to the machine
         cmds.append(' '.join([
             'add_host',
-            f'--hostname {device.primary_ip.dns_name}',
+            f'--hostname {device.primary_ip4.dns_name}',
             f'--machine {device.aq_machine_name}',
             f'--archetype {opts.archetype}',
-            f'--ip {device.primary_ip.address.split("/")[0]}',
+            f'--ip {device.primary_ip4.address.split("/")[0]}',
             f'--personality {personality}',
             f'--{aqdesttype} {aqdestval}',
             f'--osname {opts.osname}',

--- a/aquilon/scd_netbox.py
+++ b/aquilon/scd_netbox.py
@@ -76,11 +76,18 @@ class SCDNetbox():
 
     def get_device_by_hostname(self, hostname):
         """ Get a single device from NetBox based on fully qualified domain name """
-        ip_address = self.netbox.ipam.ip_addresses.get(dns_name=hostname)
-        if ip_address is None:
+        ip_addresses = self.netbox.ipam.ip_addresses.filter(dns_name=hostname, family=4)
+        if ip_addresses is None:
             logging.error("Hostname not found in NetBox")
             sys.exit(1)
 
+        ip_addresses = list(ip_addresses)
+
+        if len(ip_addresses) > 1:
+            logging.error("Got multiple IPs %s for hostname %s", ip_addresses, hostname)
+            sys.exit(1)
+
+        ip_address = ip_addresses[0]
         logging.debug("Got IP %s for hostname %s", ip_address, hostname)
 
         # The ip_address is assigned to an object, which is what we are after,


### PR DESCRIPTION
As previously noted, we only support IPv4 addresses for the managed host objects in aquilon, if hosts are dual-stacked we need to ignore the IPv6 address. We also need to throw an error and exit if the primary hostname is assigned to more than one address as this cannot be supported.

Fixes #31.